### PR TITLE
feature: add `pull` command to sync latest dotfiles from remote

### DIFF
--- a/src/dotctl/actions/activator.py
+++ b/src/dotctl/actions/activator.py
@@ -10,6 +10,7 @@ from dotctl.handlers.git_handler import (
     get_repo_branches,
     git_fetch,
     checkout_branch,
+    pull_changes,
 )
 from dotctl.exception import exception_handler
 
@@ -57,6 +58,10 @@ def apply(props: ActivatorProps) -> None:
             return
 
     config = conf_reader(config_file=Path(app_config_file))
+
+    if pull_changes(repo):
+        log("✅ Pulled latest changes from cloud successfully.")
+
     if not props.skip_hooks and not props.skip_pre_hooks:
         run_hooks(
             pre_apply_hooks=True,
@@ -90,4 +95,4 @@ def apply(props: ActivatorProps) -> None:
             ignore_errors=props.ignore_hook_errors,
             timeout=props.hooks_timeout,
         )
-    log("Profile saved successfully!")
+    log("✅ Profile saved successfully!")

--- a/src/dotctl/actions/puller.py
+++ b/src/dotctl/actions/puller.py
@@ -1,0 +1,34 @@
+import shutil
+from pathlib import Path
+from datetime import datetime
+from dataclasses import dataclass
+from dotctl.paths import app_profile_directory
+from dotctl.utils import log
+from dotctl.exception import exception_handler
+from dotctl.handlers.git_handler import get_repo, pull_changes
+from dotctl import __APP_NAME__, __DEFAULT_PROFILE__
+
+
+@dataclass
+class PullerProps:
+    profile_dir: Path
+
+
+puller_default_props = PullerProps(
+    profile_dir=Path(app_profile_directory),
+)
+
+
+@exception_handler
+def pull(props: PullerProps):
+    log("Pulling profile changes...")
+    repo = get_repo(props.profile_dir)
+    try:
+        changes = pull_changes(repo)
+        if changes is None:
+            log("✅ Profile already up to date.")
+        elif changes:
+            log("✅ Pulled latest changes successfully.")
+
+    except Exception as e:
+        raise Exception(f"Unexpected error: {e}")

--- a/src/dotctl/actions/saver.py
+++ b/src/dotctl/actions/saver.py
@@ -10,6 +10,7 @@ from dotctl.handlers.git_handler import (
     get_repo,
     get_repo_branches,
     git_fetch,
+    pull_changes,
     checkout_branch,
     create_branch,
     is_repo_changed,
@@ -54,6 +55,8 @@ def save(props: SaverProps) -> None:
         else:
             create_branch(repo=repo, branch=profile)
             log(f"Profile '{profile}' created and activated successfully.")
+    if pull_changes(repo):
+        log("✅ Pulled latest changes from cloud successfully.")
 
     config = conf_reader(config_file=Path(app_config_file))
 
@@ -92,6 +95,6 @@ def save(props: SaverProps) -> None:
                 push_new_branch(repo=repo)
             else:
                 push_existing_branch(repo=repo)
-        log("Profile saved successfully!")
+        log("✅ Profile saved successfully!")
     else:
         log("No changes detected!")

--- a/src/dotctl/arg_manager.py
+++ b/src/dotctl/arg_manager.py
@@ -274,6 +274,11 @@ def get_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Skip all sudo operations",
     )
+    # Pull Parser
+    pull_parser = subparsers.add_parser(
+        "pull", help="Pull the latest changes from the dotfiles repository"
+    )
+
     # Wipe Parser
     wipe_parser = subparsers.add_parser("wipe", help="Wipe Profiles")
 

--- a/src/dotctl/handlers/git_handler.py
+++ b/src/dotctl/handlers/git_handler.py
@@ -226,13 +226,11 @@ def push_new_branch(repo: Repo) -> None:
         )
 
 
-def pull_changes(repo: Repo) -> None | bool:
+def pull_changes(repo: Repo) -> bool | None:
     is_remote, origin = is_remote_repo(repo)
     if not is_remote or origin is None:
-        log(
-            "Warning: Skipping pull from remote repository. This is not a remote repository."
-        )
-        return
+        log("Warning: Skipping pull. This is not a remote repository.")
+        return None
 
     if repo.bare:
         raise Exception("Error: The repository is bare. Cannot pull changes.")
@@ -249,6 +247,7 @@ def pull_changes(repo: Repo) -> None | bool:
     log("📥 Update found:")
     for commit in repo.iter_commits(f"{current_branch}..origin/{current_branch}"):
         log(f" - {commit.summary} ({commit.hexsha[:7]})")
+
     origin.pull()
     return True
 

--- a/src/dotctl/handlers/git_handler.py
+++ b/src/dotctl/handlers/git_handler.py
@@ -226,6 +226,33 @@ def push_new_branch(repo: Repo) -> None:
         )
 
 
+def pull_changes(repo: Repo) -> None | bool:
+    is_remote, origin = is_remote_repo(repo)
+    if not is_remote or origin is None:
+        log(
+            "Warning: Skipping pull from remote repository. This is not a remote repository."
+        )
+        return
+
+    if repo.bare:
+        raise Exception("Error: The repository is bare. Cannot pull changes.")
+
+    git_fetch(repo)
+
+    current_branch = repo.active_branch.name
+    local_commit = repo.commit(current_branch)
+    remote_commit = repo.commit(f"origin/{current_branch}")
+
+    if local_commit.hexsha == remote_commit.hexsha:
+        return None
+
+    log("📥 Update found:")
+    for commit in repo.iter_commits(f"{current_branch}..origin/{current_branch}"):
+        log(f" - {commit.summary} ({commit.hexsha[:7]})")
+    origin.pull()
+    return True
+
+
 def get_repo_meta(repo: Repo) -> RepoMetaData:
 
     if repo.bare:

--- a/src/dotctl/main.py
+++ b/src/dotctl/main.py
@@ -9,6 +9,7 @@ from .actions.saver import save, saver_default_props
 from .actions.activator import apply, activator_default_props
 from .actions.lister import get_profile_list, lister_default_props
 from .actions.switcher import switch, switcher_default_props
+from .actions.puller import pull, puller_default_props
 from .actions.creator import create, creator_default_props
 from .actions.remover import remove, remover_default_props
 from .actions.exporter import exporter, exporter_default_props
@@ -22,6 +23,7 @@ class Action(Enum):
     LS = "ls"
     SWITCH = "switch"
     SW = "sw"
+    PULL = "pull"
     SAVE = "save"
     APPLY = "apply"
     CREATE = "create"
@@ -52,6 +54,7 @@ class DotCtl:
             Action.LS: self.list_profiles,
             Action.SWITCH: self.switch_profile,
             Action.SW: self.switch_profile,
+            Action.PULL: self.pull_profile,
             Action.CREATE: self.create_profile,
             Action.NEW: self.create_profile,
             Action.REMOVE: self.remove_profile,
@@ -140,6 +143,10 @@ class DotCtl:
         """Wipe dotfiles profile."""
         props = self._build_props(wiper_default_props, "no_confirm")
         wipe(props)
+
+    def pull_profile(self):
+        """Pull dotfiles profile."""
+        pull(puller_default_props)
 
 
 @exception_handler


### PR DESCRIPTION
### ✨ New Feature: `dotctl pull`

This PR introduces a new `dotctl pull` command that allows users to pull the latest changes from the dotfiles repository before applying or saving any changes.

### 🔧 Changes Made
- Added `pull` subcommand to CLI
- Introduced `pull_changes(repo)` function to:
  - Fetch changes from the remote
  - Check if local is behind remote
  - Show summary of incoming commits
  - Perform `git pull` only if there are new commits
- Integrated `pull_changes` automatically before `dotctl apply` and `dotctl save` commands

### ✅ Behavior
- If no changes: no pull is performed, stays quiet
- If changes exist: shows commits being pulled and confirms success
- If repo is not remote or bare: skips pull with appropriate handling

This ensures dotctl always stays in sync with the remote repository, reducing the chance of conflicts or outdated state.
