### PR TITLE
fix(init): prevent overwriting hooks/config when initializing with remote and profile

### DIFF
--- a/src/dotctl/actions/initializer.py
+++ b/src/dotctl/actions/initializer.py
@@ -66,16 +66,21 @@ def initialise(props: InitializerProps):
         raise Exception(f"Failed to initialize profile repo at {props.dest}. ")
     if props.profile:
         checkout_branch(repo, props.profile)
+        log(f"Switching to Profile `{props.profile}`.")
 
     if props.config is not None and isinstance(props.config, str):
         props.config = Path(props.config)
 
-    conf_initializer(
-        env=props.env,
-        custom_config=props.config,
-    )
-    hooks_initializer()
+    initialized_config = conf_initializer(env=props.env, custom_config=props.config)
+    if initialized_config is not None:
+        log(f"Config initialized successfully.")
+
+    initialized_hooks = hooks_initializer()
+    if initialized_hooks:
+        log(f"Hooks initialized successfully {initialized_hooks}.")
+
     add_changes(repo=repo)
+
     if is_repo_changed(repo=repo):
         hostname = socket.gethostname()
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -94,4 +99,4 @@ def initialise(props: InitializerProps):
             else:
                 push_existing_branch(repo=repo)
 
-    log("Profile initialized successfully.")
+    log("✅ Profile initialized successfully.")

--- a/src/dotctl/handlers/config_handler.py
+++ b/src/dotctl/handlers/config_handler.py
@@ -91,10 +91,10 @@ def conf_initializer(
     env: str | None = None,
     custom_config: Path | None = None,
     app_config_file_path: Path = Path(app_config_file),
-) -> Path:
+) -> Path | None:
 
     if app_config_file_path.exists():
-        return app_config_file_path
+        return None
 
     if custom_config:
         log(f"Using custom config file: {custom_config}")

--- a/src/dotctl/handlers/hooks_handler.py
+++ b/src/dotctl/handlers/hooks_handler.py
@@ -7,10 +7,20 @@ from dotctl.utils import log, new_line
 from .data_handler import copy
 
 
-def hooks_initializer(app_hooks_dir_path: Path = Path(app_hooks_directory)):
+def hooks_initializer(
+    app_hooks_dir_path: Path = Path(app_hooks_directory),
+) -> list[Path]:
     app_hooks_dir_path.mkdir(parents=True, exist_ok=True)
     hooks_base_dir = Path(__BASE_DIR__) / "hooks"
-    copy(hooks_base_dir, app_hooks_dir_path)
+
+    initialized_hooks = []
+    for hook_file in hooks_base_dir.iterdir():
+        target_file = app_hooks_dir_path / hook_file.name
+        if not target_file.exists():
+            copy(hook_file, target_file)
+            initialized_hooks.append(hook_file.name)
+
+    return initialized_hooks
 
 
 def run_shell_script(


### PR DESCRIPTION
### 🐞 Bug Fix: Preserve existing hooks/config during `dotctl init`

This PR fixes an issue where running `dotctl init` with both a remote repository and a specific profile (using `-p`) would overwrite existing `hooks/` and `dotctl.yaml` with default templates, even if those already exist in the repository.

### ✅ New Behavior
- During `init`, only missing hook and config files are copied from the default template.
- Existing hook files in the app hooks directory are left untouched.
- Prevents accidental overwrites and respects the structure of the cloned repository.

### 🔧 Implementation
`hooks_initializer()` and `conf_initializer()` now checks if each file exists before copying from the default template.

This ensures that users initializing dotctl with a remote and a profile don't lose their customized hooks or configurations.